### PR TITLE
Add ts-ignore to suppress import errors in Rule files

### DIFF
--- a/src/assets/docs/views/rules/Rule1.vue
+++ b/src/assets/docs/views/rules/Rule1.vue
@@ -1,8 +1,12 @@
 <script setup lang="ts">
 import {NH1, NH2, NList, NListItem, NText, NAlert} from "naive-ui";
+// @ts-ignore
 import OnePointOne from "@/assets/docs/mds/rules/1/1.1.md";
+// @ts-ignore
 import OnePointTwo from "@/assets/docs/mds/rules/1/1.2.md";
+// @ts-ignore
 import OnePointThree from "@/assets/docs/mds/rules/1/1.3.md";
+// @ts-ignore
 import OnePointFour from "@/assets/docs/mds/rules/1/1.4.md";
 </script>
 

--- a/src/assets/docs/views/rules/Rule2.vue
+++ b/src/assets/docs/views/rules/Rule2.vue
@@ -1,12 +1,20 @@
 <script setup lang="ts">
 import {NH1, NH2, NList, NListItem, NText, NAlert} from "naive-ui";
+// @ts-ignore
 import TwoOne from "@/assets/docs/mds/rules/2/2.1.md"
+// @ts-ignore
 import TwoTwo from "@/assets/docs/mds/rules/2/2.2.md"
+// @ts-ignore
 import TwoThree from "@/assets/docs/mds/rules/2/2.3.md"
+// @ts-ignore
 import TwoThreeOne from "@/assets/docs/mds/rules/2/2.3.1.md"
+// @ts-ignore
 import TwoFour from "@/assets/docs/mds/rules/2/2.4.md"
+// @ts-ignore
 import TwoFive from "@/assets/docs/mds/rules/2/2.5.md"
+// @ts-ignore
 import TwoSix from "@/assets/docs/mds/rules/2/2.6.md"
+// @ts-ignore
 import TwoSeven from "@/assets/docs/mds/rules/2/2.7.md"
 </script>
 


### PR DESCRIPTION
A series of `// @ts-ignore` comments have been added above each markdown import in both Rule1.vue and Rule2.vue files. This is to suppress the TypeScript compiler warnings raised due to the importing of .md files, which TypeScript cannot recognize. This change does not affect the actual functionality, but improves the developer experience by reducing unnecessary error messages.